### PR TITLE
Fixing a broken command line argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ module.exports = {
       port: 3000,
       ignore: ['node_modules'],
       unzipped: true,
-      silent: true,
-      verbosity: true
+      silent: true
     }, opts)
 
     const dir = yield this.$.expand(globs, {mark: true})

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
     const defOpts = Object.assign({
       port: 3000,
       ignore: ['node_modules'],
-      unziped: true,
+      unzipped: true,
       silent: true,
       verbosity: true
     }, opts)


### PR DESCRIPTION
In the current version, the `unzipped` command line option is wrong and gives this feedback:

```
The option "unziped" is unknown. Did you mean the following one?
-u, --unzipped  Disable GZIP compression
```

Additionally, `verbosity` is not a valid one either.